### PR TITLE
utilities to identify buggy connections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ import org.gradle.internal.os.OperatingSystem
 import java.nio.file.Files
 
 group 'ro.mirceanistor.stf'
-version '0.4'
+version '0.5'
 
 apply plugin: 'groovy'
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     compile 'org.codehaus.groovy:groovy-json:2.4.7'
 
     compile "org.codehaus.gpars:gpars:1.2.1"
+    compile 'org.codehaus.jsr166-mirror:jsr166y:1.7.0'
 
     compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     compile 'org.codehaus.groovy:groovy-xml:2.4.7'
     compile 'org.codehaus.groovy:groovy-json:2.4.7'
 
+    compile "org.codehaus.gpars:gpars:1.2.1"
+
     compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7'
 }
 

--- a/src/main/groovy/ro/mirceanistor/stf/MainClass.groovy
+++ b/src/main/groovy/ro/mirceanistor/stf/MainClass.groovy
@@ -33,6 +33,7 @@ class MainClass {
     public static final String C_FILTER = "filter"
     public static final String C_QUIET = "quiet"
     public static final String C_SHOW = "show"
+    public static final String C_DIFF = "diff"
 
     static void main(String[] args) {
 
@@ -46,6 +47,7 @@ class MainClass {
             options.addOption("q", C_QUIET, false, "only output device serials, nothing else. Negates --verbose option")
 
             options.addOption("l", C_LIST, false, "list available devices.\nCan be combined with --filter option to only show subsets")
+            options.addOption("d", C_DIFF, false, "list allocated devices that don't appear usable in adb-devices\n Can be combined with --filter to be more specific.")
             options.addOption("a", C_ALLOCATE, false, "allocate devices to the current user\nBy default, this reserves every available device.\nIt's best to combine with --filter option to be more specific")
             options.addOption("r", C_RELEASE, false, "release allocated devices\nBy default it releases all but can be combined with --filter to be more specific")
             options.addOption("c", C_CONNECT, false, "connect to reserved devices\nBy default it connects to every allocated device.\n Can be combined with --filter to be more specific.")
@@ -115,10 +117,25 @@ class MainClass {
             if (commandLine.hasOption(C_LIST)) {
 
                 //by default, show all available devices
-                def filters = (rawFilters.size() == 0 ? [ "free" ] : rawFilters)
+                def filters = (rawFilters.size() == 0 ? ["free"] : rawFilters)
 
                 def devices = new STF(filters).queryDevices()
                 devices.each {
+                    if (QUIET_OUTPUT) {
+                        println it.serial
+                    } else {
+                        println it
+                    }
+                }
+                hasAction = true
+            }
+
+            if (commandLine.hasOption(C_DIFF)) {
+
+                def stf = new STF(rawFilters + "using")
+                def devices = stf.queryDevices()
+                def diffed = STF.diffDevices(devices)
+                diffed.each {
                     if (QUIET_OUTPUT) {
                         println it.serial
                     } else {

--- a/src/main/groovy/ro/mirceanistor/stf/MainClass.groovy
+++ b/src/main/groovy/ro/mirceanistor/stf/MainClass.groovy
@@ -32,6 +32,7 @@ class MainClass {
     public static final String C_CONNECT = "connect"
     public static final String C_FILTER = "filter"
     public static final String C_QUIET = "quiet"
+    public static final String C_SHOW = "show"
 
     static void main(String[] args) {
 
@@ -48,6 +49,7 @@ class MainClass {
             options.addOption("a", C_ALLOCATE, false, "allocate devices to the current user\nBy default, this reserves every available device.\nIt's best to combine with --filter option to be more specific")
             options.addOption("r", C_RELEASE, false, "release allocated devices\nBy default it releases all but can be combined with --filter to be more specific")
             options.addOption("c", C_CONNECT, false, "connect to reserved devices\nBy default it connects to every allocated device.\n Can be combined with --filter to be more specific.")
+            options.addOption("s", C_SHOW, false, "light up the screens of connected devices. Equivalent to 'find device' from the web console\n Can be combined with --filter to be more specific.")
 
             Option filterOption = new Option("f", C_FILTER, true, "filter devices, can be used multiple times to filter by multiple fields.\n" +
                     "If the same field is specified in more than one filter, ONLY the FIRST one is used.\n" +
@@ -123,6 +125,13 @@ class MainClass {
                         println it
                     }
                 }
+                hasAction = true
+            }
+
+            if (commandLine.hasOption(C_SHOW)) {
+                STF stf = new STF(rawFilters + "using")
+                def deviceSerials = stf.queryDevices()
+                stf.showDevices(deviceSerials)
                 hasAction = true
             }
 

--- a/src/main/groovy/ro/mirceanistor/stf/STF.groovy
+++ b/src/main/groovy/ro/mirceanistor/stf/STF.groovy
@@ -355,4 +355,32 @@ class STF {
         }
     }
 
+    /**
+     * Generates a collection of devices that are reserved but aren't usable in "adb devices"
+     * @param myDevices devices passed in by another filter
+     * @return
+     */
+    static def diffDevices(Collection<DeviceInfo> myDevices) {
+
+        def adbDevicesOutput = "adb devices".execute().text.readLines()
+
+        Collection<String> connectedDevices = adbDevicesOutput.collect {
+            if (it.contains("List of devices attached") || it.trim().length() == 0) {
+                return null
+            }
+            def tokens = it.split(/\s/)
+            if (tokens.length < 2 || !tokens[1].contains("device")) {
+                return null
+            }
+            return tokens[0]
+        }
+
+        def diffedDevices = new LinkedList(myDevices)
+        diffedDevices.removeAll {
+            connectedDevices?.contains(it.remoteConnectUrl)
+        }
+
+        return diffedDevices
+    }
+
 }

--- a/src/main/groovy/ro/mirceanistor/stf/STF.groovy
+++ b/src/main/groovy/ro/mirceanistor/stf/STF.groovy
@@ -297,19 +297,17 @@ class STF {
 
         logger?.info "There are ${devicesToConnect.size} devices to connect to."
 
-        withPool {
-            devicesToConnect.eachParallel {
-                def connectionString = it.remoteConnectUrl
+        devicesToConnect.each {
+            def connectionString = it.remoteConnectUrl
 
-                if (it.remoteConnectUrl == null) {
-                    it.remoteConnectUrl = getConnectionString(it.serial)
-                    logger?.info "got RemoteConnectUrl=${it.remoteConnectUrl}"
-                }
-
-                logger?.info "connecting ADB to ${connectionString}"
-                def adbConnectOutput = "adb connect $connectionString".execute().text
-                logger?.info adbConnectOutput
+            if (it.remoteConnectUrl == null) {
+                it.remoteConnectUrl = getConnectionString(it.serial)
+                logger?.info "got RemoteConnectUrl=${it.remoteConnectUrl}"
             }
+
+            logger?.info "connecting ADB to ${connectionString}"
+            def adbConnectOutput = "adb connect $connectionString".execute().text
+            logger?.info adbConnectOutput
         }
 
         def adbDevicesOutput = "adb devices".execute().text


### PR DESCRIPTION
added 2 new commands
`stfc --diff` - lists the devices that are allocated to the current user but not connected through `adb`
`stfc --show` - lights up the screens of connected devices (equivalent to "find device" from the web console)

Both can be combined with `--filter` for more specific bisecting and should make it a bit easier to handle buggy cables or devices when dealing with a bigger lot.