### PR TITLE
Fix #11 - first install issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,12 @@ task install(dependsOn: fatJar) {
                     bashStrap.text += "java -jar \"${jarLocation}\" \$@"
                     bashStrap.setExecutable(true, true)
                     //symlink to the bash script
-                    Files.delete(symlinkPath)
+                    try {
+                        Files.delete(symlinkPath)
+                    } catch (IOException ex) {
+                        logger.debug("there was an exception when trying to delete old symlink:", ex)
+                    }
+                    Files.createDirectories(symlinkPath.parent)
                     Files.createSymbolicLink(symlinkPath, new File(installLocation).toPath())
 
                     logger.lifecycle("\nCreated \"stfc\" bootstrap in \"${installDir}\".\n" +


### PR DESCRIPTION
catch exceptions if the old symlink can't be deleted on install (which is the case if the link does not exist)
also, ensure directories exist before trying to create the symlink